### PR TITLE
BlockプレファブのColliderにoffsetが入っていたのをリセット

### DIFF
--- a/Assets/Prefabs/Block_Template.prefab
+++ b/Assets/Prefabs/Block_Template.prefab
@@ -201,7 +201,7 @@ BoxCollider2D:
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0
-  m_Offset: {x: 8, y: 8}
+  m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}


### PR DESCRIPTION
* https://github.com/erogemy/BlockBreakerTemplate/commit/a7556a1ca1f4da3f476142b066d6560d06d6e189 で `boxCollider.offset = size / 2;` を消したのでテンプレのoffsetがそのまま入ってしまった