### PR TITLE
シーンの上書きを続けるとシーンが壊れていく不具合修正

### DIFF
--- a/Assets/Editor/Scripts/BlockBreakerBuilder.cs
+++ b/Assets/Editor/Scripts/BlockBreakerBuilder.cs
@@ -146,8 +146,10 @@ namespace Erogemy.BlockBreaker.Editor
                     return false;
                 }
 
+                // CopyAssetはmetaが変わるのでFile.Copy
+                File.Copy(EditorConsts.PackagePath + EditorConsts.BlockBreakerTemplatePath, EditorConsts.BlockBreakerScenePath, true);
                 // シーンを開いておく
-                UnityEditor.SceneManagement.EditorSceneManager.OpenScene(EditorConsts.BlockBreakerScenePath);
+                EditorSceneManager.OpenScene(EditorConsts.BlockBreakerScenePath);
                 return true;
             }
 
@@ -160,7 +162,7 @@ namespace Erogemy.BlockBreaker.Editor
                 return false;
             }
 
-            UnityEditor.SceneManagement.EditorSceneManager.OpenScene(EditorConsts.BlockBreakerScenePath);
+            EditorSceneManager.OpenScene(EditorConsts.BlockBreakerScenePath);
 
             return true;
         }

--- a/Assets/Editor/Scripts/BlockBreakerBuilder.cs
+++ b/Assets/Editor/Scripts/BlockBreakerBuilder.cs
@@ -31,6 +31,10 @@ namespace Erogemy.BlockBreaker.Editor
 
             SetupBlockImage(phaseCount, blockSize);
             SetupScene(phaseCount, blockSize, settings);
+
+            var scene = SceneManager.GetActiveScene();
+            Canvas.ForceUpdateCanvases(); // これがないとRectTransformのposがSaveされない
+            EditorSceneManager.SaveScene(scene, EditorConsts.BlockBreakerScenePath);
         }
 
         static void SetupScene(int phaseCount, Vector2Int blockSize, BockBreakerSettings settings)


### PR DESCRIPTION
* 従来の上書き処理は既存シーンを開いてprefabを配置するだけだったので、Phaseが配置済だと重複して配置するという問題があった
* 警告ダイアログは出しているので文字通り「ファイルの上書き」にした
* ついでにシーンの作成が終わったらちゃんとシーンを保存するようにした
