### PR TITLE
ブロックの当たり判定がズレる不具合修正

### DIFF
--- a/Assets/Prefabs/Block_Template.prefab
+++ b/Assets/Prefabs/Block_Template.prefab
@@ -114,7 +114,7 @@ RectTransform:
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 16, y: 16}
-  m_Pivot: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1116505034669237827
 CanvasRenderer:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
* RectTransformのpivotが0,0になっていて、BoxColliderが左下始まりになっていた
* pivotが0.5, 0.5でもブロック配置処理には影響しないようになっているのでtemplate prefab側でpivotをセンタリングした（多分 #12 のコミット漏れ）